### PR TITLE
🔧 Add fix path module

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -1,3 +1,4 @@
+import fixpath from 'fix-path';
 import menubar from 'menubar';
 import electron, { ipcMain } from 'electron';
 
@@ -16,6 +17,8 @@ import {
   REMOVE_PROJECT,
   PROJECT_REMOVED,
 } from './src/ipc-events';
+
+fixpath();
 
 const app = electron.app;
 

--- a/app/package.json
+++ b/app/package.json
@@ -33,6 +33,7 @@
     "electron-packager": "^8.2.0",
     "electron-prebuilt": "^1.4.6",
     "file-loader": "^0.9.0",
+    "fix-path": "^2.1.0",
     "lodash.debounce": "^4.0.8",
     "menubar": "^5.1.0",
     "moment": "^2.16.0",


### PR DESCRIPTION
Resolves user `$PATH` variable when opened by double clicking the app icon.